### PR TITLE
Support for writing DTLS 1.3 unified header

### DIFF
--- a/ssl/record/methods/build.info
+++ b/ssl/record/methods/build.info
@@ -5,7 +5,7 @@ ENDIF
 
 SOURCE[../../../libssl]=\
         tls_common.c ssl3_meth.c tls1_meth.c tls13_meth.c tlsany_meth.c \
-        dtls_meth.c tls_multib.c $KTLSSRC
+        dtls_meth.c dtls13_meth.c tls_multib.c $KTLSSRC
 
 # For shared builds we need to include the sources needed in providers
 # (ssl3_cbc.c) in libssl as well.

--- a/ssl/record/methods/dtls13_meth.c
+++ b/ssl/record/methods/dtls13_meth.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018-2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "../../ssl_local.h"
+#include "recmethod_local.h"
+
+#define DTLS13_FIXED_BITS   0x20
+#define DTLS13_CBIT         0x10
+#define DTLS13_SBIT         0x08
+#define DTLS13_LBIT         0x04
+#define DTLS13_EPOCH_MASK   0x03
+
+int dtls13_prepare_record_header(OSSL_RECORD_LAYER *rl,
+                               WPACKET *thispkt,
+                               OSSL_RECORD_TEMPLATE *templ,
+                               unsigned int rectype,
+                               unsigned char **recdata,
+                               TLS_RL_RECORD *thiswr)
+{
+    size_t maxcomplen;
+
+    *recdata = NULL;
+
+    maxcomplen = templ->buflen;
+    if (rl->compctx != NULL)
+        maxcomplen += SSL3_RT_MAX_COMPRESSED_OVERHEAD;
+
+    if (rectype == SSL3_RT_APPLICATION_DATA) {
+        /* DTLSCiphertext. TODO (DTLSv1.3): Ensure that we always use SSL3_RT_APPLICATION_DATA when encrypting in DTLS 1.3
+        (as in TLS 1.3, see tls13_get_record_type()) or alternatively add required conditionals for capturing all 
+        DTLSCiphertext messages here */
+        thiswr->unified_hdr.cbit_is_set = 0;
+        /*TODO (DTLSv1.3): statically forced to use 16-bit sequence id right now, implement optional Sequence Number field*/
+        thiswr->unified_hdr.sbit_is_set = 1;
+        /*TODO (DTLSv1.3): statically forced to use 16-bit length field right now, implement optional Length field*/
+        thiswr->unified_hdr.lbit_is_set = 1;
+
+        /*First byte*/
+        thiswr->unified_hdr.first_byte = DTLS13_FIXED_BITS;
+
+        if (thiswr->unified_hdr.cbit_is_set) {
+            thiswr->unified_hdr.first_byte |= DTLS13_CBIT;
+        }
+        if (thiswr->unified_hdr.sbit_is_set) {
+            thiswr->unified_hdr.first_byte |= DTLS13_SBIT;
+        }
+        if (thiswr->unified_hdr.lbit_is_set) {
+            thiswr->unified_hdr.first_byte |= DTLS13_LBIT;
+        }
+
+        /* Extracting low-order bytes (big-endian)*/
+        if (thiswr->unified_hdr.sbit_is_set) {
+            if (SEQ_NUM_SIZE < 2) {
+                goto err;
+            }
+            /* Low-order 2 bytes*/
+            memcpy(thiswr->unified_hdr.seq, rl->sequence + (SEQ_NUM_SIZE - 2), 2);
+        } else {
+            if (SEQ_NUM_SIZE < 1) {
+                goto err;
+            }
+            /* Low-order 8 byte*/
+            thiswr->unified_hdr.seq[0] = rl->sequence[SEQ_NUM_SIZE - 1];
+        }
+
+        /* The two low bits (0x03) include the low-order two bits of the epoch.*/
+        thiswr->unified_hdr.first_byte |= (rl->epoch & DTLS13_EPOCH_MASK);
+
+        if (!WPACKET_put_bytes_u8(thispkt, thiswr->unified_hdr.first_byte)
+            /* TODO (DTLSv1.3): add support for Connection ID (CID), length as negotiated*/
+            || !WPACKET_put_bytes_u8(thispkt, thiswr->unified_hdr.seq[0])
+            || !(thiswr->unified_hdr.sbit_is_set
+                ? WPACKET_put_bytes_u8(thispkt, thiswr->unified_hdr.seq[1]) : 1)
+            || !(thiswr->unified_hdr.lbit_is_set
+                ? WPACKET_put_bytes_u16(thispkt, templ->buflen) : 1)
+            || (rl->eivlen > 0
+                && !WPACKET_allocate_bytes(thispkt, rl->eivlen, NULL))
+            || (maxcomplen > 0
+                && !WPACKET_reserve_bytes(thispkt, maxcomplen,
+                                        recdata))) {
+            goto err;
+        }
+
+        thiswr->unified_hdr.valid = 1;
+    } else {
+        /* DTLSPlaintext */
+        if (!WPACKET_put_bytes_u8(thispkt, rectype)
+                || !WPACKET_put_bytes_u16(thispkt, templ->version)
+                || !WPACKET_put_bytes_u16(thispkt, rl->epoch)
+                || !WPACKET_memcpy(thispkt, &(rl->sequence[2]), 6)
+                || !WPACKET_start_sub_packet_u16(thispkt)
+                || (rl->eivlen > 0
+                    && !WPACKET_allocate_bytes(thispkt, rl->eivlen, NULL))
+                || (maxcomplen > 0
+                    && !WPACKET_reserve_bytes(thispkt, maxcomplen,
+                                            recdata))) {
+            goto err;
+        }
+        thiswr->unified_hdr.valid = 0;
+    }
+
+    return 1;
+
+err:
+    RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+    return 0;
+}

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -703,7 +703,8 @@ int dtls_prepare_record_header(OSSL_RECORD_LAYER *rl,
                                WPACKET *thispkt,
                                OSSL_RECORD_TEMPLATE *templ,
                                unsigned int rectype,
-                               unsigned char **recdata)
+                               unsigned char **recdata,
+                               TLS_RL_RECORD *thiswr)
 {
     size_t maxcomplen;
 

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -494,7 +494,8 @@ static int ktls_prepare_record_header(OSSL_RECORD_LAYER *rl,
                                       WPACKET *thispkt,
                                       OSSL_RECORD_TEMPLATE *templ,
                                       unsigned int rectype,
-                                      unsigned char **recdata)
+                                      unsigned char **recdata,
+                                      TLS_RL_RECORD *thiswr)
 {
     /* The kernel writes the record header, so nothing to do */
     *recdata = NULL;

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -436,6 +436,12 @@ int dtls_prepare_record_header(OSSL_RECORD_LAYER *rl,
                                unsigned int rectype,
                                unsigned char **recdata,
                                TLS_RL_RECORD *thiswr);
+int dtls13_prepare_record_header(OSSL_RECORD_LAYER *rl,
+                               WPACKET *thispkt,
+                               OSSL_RECORD_TEMPLATE *templ,
+                               unsigned int rectype,
+                               unsigned char **recdata,
+                               TLS_RL_RECORD *thiswr);
 int dtls_post_encryption_processing(OSSL_RECORD_LAYER *rl,
                                     size_t mac_size,
                                     OSSL_RECORD_TEMPLATE *thistempl,

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -186,7 +186,8 @@ struct record_functions_st
     int (*prepare_record_header)(OSSL_RECORD_LAYER *rl, WPACKET *thispkt,
                                  OSSL_RECORD_TEMPLATE *templ,
                                  unsigned int rectype,
-                                 unsigned char **recdata);
+                                 unsigned char **recdata,
+                                 TLS_RL_RECORD *thiswr);
 
     int (*add_record_padding)(OSSL_RECORD_LAYER *rl,
                               OSSL_RECORD_TEMPLATE *thistempl,
@@ -433,7 +434,8 @@ int dtls_prepare_record_header(OSSL_RECORD_LAYER *rl,
                                WPACKET *thispkt,
                                OSSL_RECORD_TEMPLATE *templ,
                                unsigned int rectype,
-                               unsigned char **recdata);
+                               unsigned char **recdata,
+                               TLS_RL_RECORD *thiswr);
 int dtls_post_encryption_processing(OSSL_RECORD_LAYER *rl,
                                     size_t mac_size,
                                     OSSL_RECORD_TEMPLATE *thistempl,
@@ -522,7 +524,8 @@ int tls_prepare_record_header_default(OSSL_RECORD_LAYER *rl,
                                       WPACKET *thispkt,
                                       OSSL_RECORD_TEMPLATE *templ,
                                       unsigned int rectype,
-                                      unsigned char **recdata);
+                                      unsigned char **recdata,
+                                      TLS_RL_RECORD *thiswr);
 int tls_prepare_for_encryption_default(OSSL_RECORD_LAYER *rl,
                                        size_t mac_size,
                                        WPACKET *thispkt,

--- a/ssl/record/methods/tls13_meth.c
+++ b/ssl/record/methods/tls13_meth.c
@@ -363,7 +363,7 @@ struct record_functions_st dtls_1_3_funcs = {
     tls_allocate_write_buffers_default,
     tls_initialise_write_packets_default,
     tls13_get_record_type, // (TODO) FWH: Seems like new stuff for TLS 1.3, check applicability for DTLS 1.3
-    dtls_prepare_record_header,
+    dtls13_prepare_record_header,
     tls13_add_record_padding, // (TODO) FWH: Seems like new stuff for TLS 1.3, check applicability for DTLS 1.3
     tls_prepare_for_encryption_default,
     dtls_post_encryption_processing,

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1575,7 +1575,8 @@ int tls_prepare_record_header_default(OSSL_RECORD_LAYER *rl,
                                       WPACKET *thispkt,
                                       OSSL_RECORD_TEMPLATE *templ,
                                       unsigned int rectype,
-                                      unsigned char **recdata)
+                                      unsigned char **recdata,
+                                      TLS_RL_RECORD *thiswr)
 {
     size_t maxcomplen;
 
@@ -1774,7 +1775,7 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
         TLS_RL_RECORD_set_rec_version(thiswr, thistempl->version);
 
         if (!rl->funcs->prepare_record_header(rl, thispkt, thistempl, rectype,
-                                              &compressdata)) {
+                                              &compressdata, thiswr)) {
             /* RLAYERfatal() already called */
             goto err;
         }


### PR DESCRIPTION
Support for writing the DTLS 1.3 unified header.  We still have to ensure that all the records to be encrypted are being passed with SSL3_RT_APPLICATION_DATA type code.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
